### PR TITLE
Add cloud URL trailing slash consistently.

### DIFF
--- a/src/component/types/Parameters.tsx
+++ b/src/component/types/Parameters.tsx
@@ -285,14 +285,14 @@ export const Parameters: React.FC<ParametersProps> = ({
                 <span className="text-muted">
                   {isLocalEnviroment
                     ? url + "/" + tabs[activeTab].method.name
-                    : url + tabs[activeTab]?.className + "/" + tabs[activeTab].method.name}
+                    : url.replace(/\/+$/, "") + "/" + tabs[activeTab]?.className + "/" + tabs[activeTab].method.name}
                 </span>{" "}
               </h6>
               <CopyButton
                 text={
                   isLocalEnviroment
                     ? url + "/" + tabs[activeTab].method.name
-                    : url + tabs[activeTab]?.className + "/" + tabs[activeTab].method.name
+                    : url.replace(/\/+$/, "") + "/" + tabs[activeTab]?.className + "/" + tabs[activeTab].method.name
                 }
               />
             </div>


### PR DESCRIPTION
Is not guaranteed that the `cloudUrl` will always have a trailing `/`. To fix it, this PR manually adds `/` at the end of the cloud URL.

This also fixes the following bug where a `/` is missing:
<img width="866" alt="image" src="https://github.com/Genez-io/test-interface-component/assets/26139486/94b8e0eb-9d00-49b9-adcd-571d878f7cf2">

