### PR TITLE
Populate gnz context

### DIFF
--- a/src/component/TestInterface.tsx
+++ b/src/component/TestInterface.tsx
@@ -434,10 +434,10 @@ export const TestInterface: React.FC<TestInterfaceProps> = (props: TestInterface
 
         if (isFullAST ? type === "Object" || type === "Array" : type.value === "Object" || type.value === "Array") {
           try {
-            param.value = JSON.parse(value);
             if (isGnzContext) {
               param.isGnzContext = isGnzContext;
             }
+            param.value = JSON.parse(value);
           } catch (e) {}
         }
       }

--- a/src/component/TestInterface.tsx
+++ b/src/component/TestInterface.tsx
@@ -333,8 +333,14 @@ export const TestInterface: React.FC<TestInterfaceProps> = (props: TestInterface
       if (param.value === "false") return false;
       if (isNaN(Number(param.value))) {
         try {
+          if (param.isGnzContext) {
+            return { ...JSON.parse(param.value ? param.value : ""), isGnzContext: true };
+          }
           return JSON.parse(param.value ? param.value : "");
         } catch (error) {
+          if (param.isGnzContext && typeof param.value === "object") {
+            return { ...param.value, isGnzContext: true };
+          }
           return param.value;
         }
       } else {
@@ -420,7 +426,7 @@ export const TestInterface: React.FC<TestInterfaceProps> = (props: TestInterface
   const filteredClass: any = classes?.filter((x: any) => x.name === currentClass?.className)[0];
   const isFullAST = filteredClass?.ast.version === "2" ? true : false;
 
-  const updateParam = (name: string, value: string, type: any) => {
+  const updateParam = (name: string, value: string, type: any, isGnzContext?: boolean) => {
     tabs[activeTab].method.params.forEach((param: Param) => {
       if (param.name === name) {
         param.value = value;
@@ -429,6 +435,9 @@ export const TestInterface: React.FC<TestInterfaceProps> = (props: TestInterface
         if (isFullAST ? type === "Object" || type === "Array" : type.value === "Object" || type.value === "Array") {
           try {
             param.value = JSON.parse(value);
+            if (isGnzContext) {
+              param.isGnzContext = isGnzContext;
+            }
           } catch (e) {}
         }
       }

--- a/src/component/types/Parameter.tsx
+++ b/src/component/types/Parameter.tsx
@@ -74,12 +74,24 @@ export const Parameter: React.FC<{
     }
     let result = "{\n";
     const keys = Object.keys(obj);
+    let gnzContextPresent = false;
+    // for (let i = 0; i < keys.length; i++) {
+    //   const key = keys[i];
+    //   const value = obj[key];
+    //   if (typeof value === "boolean" && key === "isGnzContext") {
+    //     gnzContextPresent = true;
+    //     break;
+    //   }
+    // }
     for (let i = 0; i < keys.length; i++) {
       const key = keys[i];
       const value = obj[key];
+      // if (typeof value === "boolean" && key === "isGnzContext") {
+      //   continue;
+      // }
       const formattedValue = typeof value === "object" ? formatObject(value, indent + 4) : JSON.stringify(value);
       result += `${indentStr}    "${key}": ${formattedValue}`;
-      if (i < keys.length - 1) {
+      if (i < (gnzContextPresent ? keys.length - 2 : keys.length - 1)) {
         result += ",";
       }
       result += "\n";

--- a/src/component/types/Parameters.tsx
+++ b/src/component/types/Parameters.tsx
@@ -141,6 +141,12 @@ export const Parameters: React.FC<ParametersProps> = ({
 
     // check if param is primitive
     if (isPrimitive(paramType.type as AstNodeType)) {
+      if ((paramType.type as AstNodeType) === AstNodeType.BooleanLiteral && paramName === "isGnzContext") {
+        return {
+          value: true,
+          label: acc + paramName,
+        };
+      }
       return {
         value: mapPrimitiveToValue(paramType.type as AstNodeType),
         label: acc + paramName,

--- a/src/component/types/Parameters.tsx
+++ b/src/component/types/Parameters.tsx
@@ -141,12 +141,6 @@ export const Parameters: React.FC<ParametersProps> = ({
 
     // check if param is primitive
     if (isPrimitive(paramType.type as AstNodeType)) {
-      if ((paramType.type as AstNodeType) === AstNodeType.BooleanLiteral && paramName === "isGnzContext") {
-        return {
-          value: true,
-          label: acc + paramName,
-        };
-      }
       return {
         value: mapPrimitiveToValue(paramType.type as AstNodeType),
         label: acc + paramName,

--- a/src/component/types/Utils.ts
+++ b/src/component/types/Utils.ts
@@ -48,7 +48,8 @@ export const typeOptions: readonly dropdownOption[] = [
 export interface Param {
   name: string;
   type: string | dropdownOption;
-  value?: string;
+  value?: any;
+  isGnzContext?: boolean;
 }
 
 export interface Method {


### PR DESCRIPTION
We needed a way to populate the GnzContext object in the Test interface, as such, any object that has the isGnzContext property will be set as a GnzContext parameter. After that, when the request is made, it will have the isGnzContext property set to true automatically